### PR TITLE
Limiting extra stars to "main" repos

### DIFF
--- a/src/Command/ThanksCommand.php
+++ b/src/Command/ThanksCommand.php
@@ -207,6 +207,7 @@ class ThanksCommand extends BaseCommand
         }
 
         $data = $file->read();
+
         return array_merge(
             isset($data['require']) ? array_keys($data['require']) : array(),
             isset($data['require-dev']) ? array_keys($data['require-dev']) : array()


### PR DESCRIPTION
This will limit starring the main metadata repo to dependencies that are *directly* in your composer.json file. This is already an "extra" star and a special situation: so this makes it more cautious.