### PR TITLE
Making illuminate/ packages thanks laravel

### DIFF
--- a/src/Command/ThanksCommand.php
+++ b/src/Command/ThanksCommand.php
@@ -46,6 +46,10 @@ class ThanksCommand extends BaseCommand
             'name' => 'laravel/laravel',
             'url' => 'https://github.com/laravel/laravel',
         ],
+        'illuminate' => [
+            'name' => 'laravel/laravel',
+            'url' => 'https://github.com/laravel/laravel',
+        ],
         'nette' => [
             'name' => 'nette/nette',
             'url' => 'https://github.com/nette/nette',


### PR DESCRIPTION
The sub-tree split for Laravel is actually under https://github.com/illuminate

