### PR TITLE
Fix: Use short syntax

### DIFF
--- a/src/Command/ThanksCommand.php
+++ b/src/Command/ThanksCommand.php
@@ -207,7 +207,7 @@ class ThanksCommand extends BaseCommand
             throw new \Exception('Could not find your composer.json file!');
         }
 
-        $data = $file->read() + array('require' => array(), 'require-dev' => array());
+        $data = $file->read() + ['require' => [], 'require-dev' => []];
         $data = array_keys($data['require'] + $data['require-dev']);
 
         return array_combine($data, $data);


### PR DESCRIPTION
This PR

* [x] uses short syntax for arrays

💁‍♂️ For reference, see: https://github.com/symfony/thanks/blob/f3e567198cbac9dbec5baf9004f1e51fecc82c79/composer.json#L12