### PR TITLE
Added PrestaShop CMS

### DIFF
--- a/src/Command/ThanksCommand.php
+++ b/src/Command/ThanksCommand.php
@@ -78,6 +78,10 @@ class ThanksCommand extends BaseCommand
             'name' => 'Sylius/Sylius',
             'url' => 'https://github.com/Sylius/Sylius',
         ],
+        'PrestaShop' => [
+            'name' => 'PrestaShop/PrestaShop',
+            'url' => 'https://github.com/PrestaShop/PrestaShop',
+        ],
         'symfony' => [
             'name' => 'symfony/symfony',
             'url' => 'https://github.com/symfony/symfony',


### PR DESCRIPTION
Looking at the hardcoded list, I 've found Sylius which is a good eCommerce project. But there is a thing:

* PrestaShop use Symfony 3.3 and we'll use 3.4 really [soon](https://github.com/PrestaShop/PrestaShop/pull/8515).
* depends on Symfony fullstack framework, Twig and Doctrine
* almost 400k active websites, probably more than 500k websites since the creation of PrestaShop

Also, we may think about add Akeneo :)