### PR TITLE
Self-star when used globally

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name": "symfony/thanks",
+    "description": "Give thanks (in the form of a GitHub ⭐) to your fellow PHP package maintainers (not limited to Symfony components)!",
     "type": "composer-plugin",
     "license": "MIT",
     "authors": [

--- a/src/Command/ThanksCommand.php
+++ b/src/Command/ThanksCommand.php
@@ -118,6 +118,7 @@ class ThanksCommand extends BaseCommand
         $urls = [
             'composer/composer' => 'https://github.com/composer/composer',
             'php/php-src' => 'https://github.com/php/php-src',
+            'symfony/thanks' => 'https://github.com/symfony/thanks',
         ];
 
         $directPackages = $this->getDirectlyRequiredPackageNames();


### PR DESCRIPTION
When Thanks is installed locally, it already gets starred, but not when installed globally (composer global require symfony/thanks).
This fixes this inconsistency.