### PR TITLE
Display a invite to run "thanks" after "composer update"

### DIFF
--- a/src/Thanks.php
+++ b/src/Thanks.php
@@ -12,18 +12,27 @@
 namespace Symfony\Thanks;
 
 use Composer\Composer;
+use Composer\EventDispatcher\EventSubscriberInterface;
 use Composer\IO\IOInterface;
+use Composer\Plugin\CommandEvent;
 use Composer\Plugin\Capability\CommandProvider;
 use Composer\Plugin\Capable;
+use Composer\Plugin\PluginEvents;
 use Composer\Plugin\PluginInterface;
+use Composer\Script\Event as ScriptEvent;
+use Composer\Script\ScriptEvents;
 
 /**
  * @author Nicolas Grekas <p@tchwork.com>
  */
-class Thanks implements Capable, CommandProvider, PluginInterface
+class Thanks implements Capable, CommandProvider, EventSubscriberInterface, PluginInterface
 {
+    private $io;
+    private $displayReminder = false;
+
     public function activate(Composer $composer, IOInterface $io)
     {
+        $this->io = $io;
     }
 
     public function getCapabilities()
@@ -37,6 +46,36 @@ class Thanks implements Capable, CommandProvider, PluginInterface
     {
         return [
             new Command\ThanksCommand(),
+        ];
+    }
+
+    public function inspectCommand(CommandEvent $event)
+    {
+        if ('update' === $event->getCommandName()) {
+            $this->displayReminder = true;
+        }
+    }
+
+    public function displayReminder(ScriptEvent $event)
+    {
+        if (!$this->displayReminder) {
+            return;
+        }
+
+        $love = '\\' === DIRECTORY_SEPARATOR ? 'love' : '💖 ';
+        $star = '\\' === DIRECTORY_SEPARATOR ? 'star' : '⭐ ';
+
+        $this->io->writeError('');
+        $this->io->writeError('What about running <comment>composer thanks</> now?');
+        $this->io->writeError(sprintf('This will spread some %s by sending a %s to the GitHub repositories of your fellow package maintainers.', $love, $star));
+        $this->io->writeError('');
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            ScriptEvents::POST_UPDATE_CMD => 'displayReminder',
+            PluginEvents::COMMAND => 'inspectCommand',
         ];
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/243674/34486727-692d49fc-efd1-11e7-8eaf-19ac04ab8ef3.png)

Only on `composer update` so that this is not displayed too often, and also because this may be the best time to send stars.