### PR TITLE
Replace ⭐ by ★

### DIFF
--- a/src/Command/ThanksCommand.php
+++ b/src/Command/ThanksCommand.php
@@ -94,14 +94,14 @@ class ThanksCommand extends BaseCommand
         ],
     ];
 
-    private $star = '⭐ ';
-    private $heart = '💖';
+    private $star = '★ ';
+    private $love = '💖 ';
 
     protected function configure()
     {
         if ('\\' === DIRECTORY_SEPARATOR) {
             $this->star = '*';
-            $this->heart = '<3';
+            $this->love = '<3';
         }
 
         $this->setName('thanks')
@@ -192,7 +192,7 @@ class ThanksCommand extends BaseCommand
             }
         }
 
-        $output->writeln(sprintf("\nThanks to you! %s", $this->heart));
+        $output->writeln(sprintf("\nThanks to you! %s", $this->love));
 
         return 0;
     }

--- a/src/Thanks.php
+++ b/src/Thanks.php
@@ -63,7 +63,7 @@ class Thanks implements Capable, CommandProvider, EventSubscriberInterface, Plug
         }
 
         $love = '\\' === DIRECTORY_SEPARATOR ? 'love' : '💖 ';
-        $star = '\\' === DIRECTORY_SEPARATOR ? 'star' : '⭐ ';
+        $star = '\\' === DIRECTORY_SEPARATOR ? 'star' : '🌟 ';
 
         $this->io->writeError('');
         $this->io->writeError('What about running <comment>composer thanks</> now?');


### PR DESCRIPTION
The ⭐ emoji contains the `\x90` byte that breaks Docker toolbox on Windows.
Let's use ★ instead.

See https://github.com/docker/toolbox/issues/695

  