### PR TITLE
Remove extra space

### DIFF
--- a/src/Thanks.php
+++ b/src/Thanks.php
@@ -73,8 +73,8 @@ class Thanks implements EventSubscriberInterface, PluginInterface
             return;
         }
 
-        $love = '\\' === DIRECTORY_SEPARATOR ? 'love' : '💖 ';
-        $star = '\\' === DIRECTORY_SEPARATOR ? 'star' : '★ ';
+        $love = '\\' === DIRECTORY_SEPARATOR ? 'love' : '💖';
+        $star = '\\' === DIRECTORY_SEPARATOR ? 'star' : '★';
 
         $this->io->writeError('');
         $this->io->writeError('What about running <comment>composer thanks</> now?');


### PR DESCRIPTION
Isn't necessary i think? 
Looks a bit ugly with extra space:
```
This will spread some 💖  by sending a ★  to the GitHub repositories of your fellow package maintainers.
```