### PR TITLE
Add "composer fund" command

### DIFF
--- a/src/Command/FundCommand.php
+++ b/src/Command/FundCommand.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Thanks\Command;
+
+use Composer\Command\BaseCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Thanks\GitHubClient;
+
+/**
+ * @author Nicolas Grekas <p@tchwork.com>
+ */
+class FundCommand extends BaseCommand
+{
+    private $star = '★ ';
+    private $love = '💖 ';
+    private $cash = '💵 ';
+
+    protected function configure()
+    {
+        if ('Hyper' === getenv('TERM_PROGRAM')) {
+            $this->star = '⭐ ';
+        } elseif ('\\' === \DIRECTORY_SEPARATOR) {
+            $this->star = '*';
+            $this->love = '<3';
+            $this->cash = '$$$';
+        }
+
+        $this->setName('fund')
+            ->setDescription(sprintf('Discover the funding links that fellow PHP package maintainers publish %s.', $this->cash))
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $composer = $this->getComposer();
+        $gitHub = new GitHubClient($composer, $this->getIO());
+
+        $repos = $gitHub->getRepositories($failures);
+        $fundings = [];
+        $notStarred = 0;
+
+        foreach ($repos as $alias => $repo) {
+            $notStarred += (int) !$repo['viewerHasStarred'];
+
+            foreach ($repo['fundingLinks'] as $link) {
+                [$owner, $package] = explode('/', $repo['package'], 2);
+                $fundings[$owner][$link['url']][] = $package;
+            }
+        }
+
+        if ($fundings) {
+            $prev = null;
+
+            $output->writeln('The following packages were found in your dependencies and publish sponsoring links on their GitHub page:');
+
+            foreach ($fundings as $owner => $links) {
+                $output->writeln(sprintf("\n<comment>%s</comment>", $owner));
+                foreach ($links as $url => $packages) {
+                    $line = sprintf("  <info>%s/%s</>", $owner, implode(', ', $packages));
+
+                    if ($prev !== $line) {
+                        $output->writeln($line);
+                        $prev = $line;
+                    }
+                    $output->writeln(sprintf("    %s %s", $this->cash, $url));
+                }
+            }
+
+            $output->writeln("\nPlease consider following these links and sponsoring the work of package authors!");
+            $output->writeln(sprintf("\nThanks you! %s", $this->love));
+        } else {
+            $output->writeln("No funding links were found in your package dependencies. That doesn't mean they don't need your support!");
+        }
+
+        if ($notStarred) {
+            $output->writeln(sprintf("\nRun <comment>composer thanks</> to send a %s to <comment>%d</comment> GitHub repositor%s of your fellow package maintainers.", $this->star, $notStarred, 1 < $notStarred ? 'ies' : 'y'));
+        }
+
+        return 0;
+    }
+}

--- a/src/Command/ThanksCommand.php
+++ b/src/Command/ThanksCommand.php
@@ -24,15 +24,16 @@ class ThanksCommand extends BaseCommand
 {
     private $star = '★ ';
     private $love = '💖 ';
+    private $cash = '💵 ';
 
     protected function configure()
     {
         if ('Hyper' === getenv('TERM_PROGRAM')) {
             $this->star = '⭐ ';
-            $this->love = '💖 ';
         } elseif ('\\' === \DIRECTORY_SEPARATOR) {
             $this->star = '*';
             $this->love = '<3';
+            $this->cash = '$$$';
         }
 
         $this->setName('thanks')
@@ -85,8 +86,9 @@ class ThanksCommand extends BaseCommand
             }
         }
 
-        $output->writeln(sprintf("\nThanks to you! %s", $this->love));
-        $output->writeln('Please consider contributing back in any way if you can!');
+        $output->writeln("\nPlease consider contributing back in any way if you can!");
+        $output->writeln(sprintf("\nRun <comment>composer fund</> to discover how you can sponsor your fellow PHP package maintainers %s", $this->cash));
+        $output->writeln(sprintf("\nThanks you! %s", $this->love));
 
         return 0;
     }

--- a/src/GitHubClient.php
+++ b/src/GitHubClient.php
@@ -144,13 +144,13 @@ class GitHubClient
         ksort($urls);
 
         $i = 0;
-        $template = '_%d: repository(owner:"%s",name:"%s"){id,viewerHasStarred}'."\n";
+        $template = '_%d: repository(owner:"%s",name:"%s"){id,viewerHasStarred,fundingLinks{platform,url}}'."\n";
         $graphql = '';
 
         foreach ($urls as $package => $url) {
             if (preg_match('#^https://github.com/([^/]++)/(.*?)(?:\.git)?$#i', $url, $url)) {
                 $graphql .= sprintf($template, ++$i, $url[1], $url[2]);
-                $aliases['_'.$i] = [$package, $url[0]];
+                $aliases['_'.$i] = [$package, sprintf('https://github.com/%s/%s', $url[1], $url[2])];
             }
         }
 

--- a/src/Thanks.php
+++ b/src/Thanks.php
@@ -56,6 +56,7 @@ class Thanks implements EventSubscriberInterface, PluginInterface
             }
 
             $app->add(new Command\ThanksCommand());
+            $app->add(new Command\FundCommand());
             break;
         }
     }


### PR DESCRIPTION
This PR is related to https://github.com/composer/packagist/pull/1050

We discussed with @naderman about the topic: new pages are coming to packagist with similar call-to-actions. Composer will soon also allow defining funding links in our `composer.json` files. A native `composer fund` command should be able to display the funding links too.

Meanwhile, this command in `symfony/thanks` provides a `composer fund` command that relies on [GitHub's funding files](https://help.github.com/en/github/building-a-strong-community/displaying-a-sponsor-button-in-your-repository).

It is designed to give the idea a try in the community while the more generic solutions are being baked.

First, run `composer global require symfony/thanks ^1.2` to install or update this command on your computer.

Then run `composer fund` and see this:

![image](https://user-images.githubusercontent.com/243674/69824452-146fcc00-120c-11ea-8f40-7a48144868ea.png)

And run `composer thanks` and see this:
![image](https://user-images.githubusercontent.com/243674/69824471-26516f00-120c-11ea-86f7-eeb670c695a0.png)

Enjoy, maintainers will thank you!