### PR TITLE
Don't register "fund" command when composer already has one

### DIFF
--- a/src/Thanks.php
+++ b/src/Thanks.php
@@ -56,7 +56,11 @@ class Thanks implements EventSubscriberInterface, PluginInterface
             }
 
             $app->add(new Command\ThanksCommand());
-            $app->add(new Command\FundCommand());
+
+            if (!$app->has('fund')) {
+                $app->add(new Command\FundCommand());
+            }
+
             break;
         }
     }


### PR DESCRIPTION
As suggested in https://github.com/symfony/thanks/pull/73#discussion_r352061669