### PR TITLE
Add support for composer-plugin-api v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^5.5.9|^7.0.0",
-        "composer-plugin-api": "^1.0"
+        "composer-plugin-api": "^1.0|^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Thanks.php
+++ b/src/Thanks.php
@@ -115,4 +115,18 @@ class Thanks implements EventSubscriberInterface, PluginInterface
             ScriptEvents::POST_UPDATE_CMD => 'displayReminder',
         ];
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function deactivate(Composer $composer, IOInterface $io)
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function uninstall(Composer $composer, IOInterface $io)
+    {
+    }
 }


### PR DESCRIPTION
Composer version 2 has `composer-plugin-api` version 2, and this plugin attemts to support both API versions.

See [What's new in Composer 2](https://php.watch/articles/composer-2) and [UPGRADE-2.0](https://github.com/composer/composer/blob/master/UPGRADE-2.0.md#for-integrators-and-plugin-authors) for more changes in API.

 - Empty methods `\Symfony\Thanks\Thanks::deactivate()` and `\Symfony\Thanks\Thanks::uninstall()` are added to make it compatible both versions.
 - On Composer v2, `\Hirak\Prestissimo\CurlRemoteFilesystem` is not used in favor of Composer's native `\Composer\Util\HttpDownloader` which make multiple Curl connections.

Related: #84 and composer/composer#8726.

`thanks` 🙏